### PR TITLE
Add conversions for POSIT numbers

### DIFF
--- a/src/POSIT.hs
+++ b/src/POSIT.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE RebindableSyntax      #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE ViewPatterns          #-}
+
+module POSIT (
+
+  Posit16(..), pattern P16_,
+  p16_to_f32, f32_to_p16,
+
+) where
+
+import Data.Array.Accelerate                    as A
+import Data.Array.Accelerate.Data.Bits          as A hiding ( bit, shift )
+
+
+newtype Posit16 = P16 Word16
+  deriving (Show, Generic)
+
+instance Elt Posit16
+instance IsProduct Elt Posit16
+
+pattern P16_ :: Exp Word16 -> Exp Posit16
+pattern P16_ p = Pattern p
+{-# COMPLETE P16_ #-}
+
+
+infixl 8 .<<.
+(.<<.) :: Bits a => Exp a -> Exp Int -> Exp a
+(.<<.) = unsafeShiftL
+
+infixl 8 .>>.
+(.>>.) :: Bits a => Exp a -> Exp Int -> Exp a
+(.>>.) = unsafeShiftR
+
+-- Convert 16-bit Posit to 32-bit IEEE Float
+--
+p16_to_f32 :: Exp Posit16 -> Exp Float
+p16_to_f32 (P16_ p) = bitcast f
+  where
+    sign :: Exp Word32
+    sign = if p .&. 0x8000 /= 0 then 0x80000000 else 0
+    f    = if p .&. 0x7FFF /= 0
+             -- decode |p|
+             then
+               let -- decode regime
+                   f0       = sign /= 0 ? ( 0x10000 - p, p )
+                   T2 f1 s1 =
+                     if f0 .&. 0x4000 /= 0
+                       then while (\(T2 f' _ ) -> f' .&. 0x2000 /= 0)
+                                  (\(T2 f' s') -> T2 (f' .<<. 1) (s' + 0x1000000))
+                                  (T2 f0 0x3f800000)
+
+                       else while (\(T2 f' _ ) -> f' .&. 0x2000 == 0)
+                                  (\(T2 f' s') -> T2 (f' .<<. 1) (s' - 0x1000000))
+                                  (T2 f0 0x3e800000)
+
+                   -- decode exponent bit
+                   shift =
+                     if f1 .&. 0x1000 /= 0
+                       then s1 + 0x800000
+                       else s1
+               in
+               sign .|. shift .|. ((fromIntegral f1 .&. 0xFFF) .<<. 11)
+
+             -- exception cases NaN and zero
+             else
+               sign /= 0 ? ( 0x7fffffff, 0)
+
+
+-- Convert 32-bit IEEE Float to 16-bit Posit with correct rounding
+--
+f32_to_p16 :: Exp Float -> Exp Posit16
+f32_to_p16 (bitcast -> f :: Exp Word32) = P16_ (fromIntegral p)
+  where
+    p :: Exp Word32
+    p = if f .&. 0x7f800000 == 0x7f800000
+          -- ±infinity, NaN become NaR
+          then 0x8000
+          else
+            -- work with |f|
+            let p0 = f .&. 0x7fffffff in
+            if  p0 == 0
+              -- ±0 both become 0
+              then 0
+              else
+                let p1 = if p0 > 0x4d000000 then 0x7fff else    -- |f| > 2^27 rounds to maxpos
+                         if p0 < 0x32000000 then 1      else    -- |f| < 2^-27 rounds to minpos
+                           let
+                             s0 = (fromIntegral p0 .>>. 23) - 127 -- power-of-2 meaning of float exponent field
+                             b0 = s0 .&. 1                        -- posit exponent bit
+
+                             -- determine number of extra regime bits needed
+                             T2 s2 p2 =
+                               if s0 >= 0
+                                 then let s1 = s0 .>>. 1
+                                      in  T2 s1 (0x3ffffff - (0x1ffffff .>>. s1))
+                                 else let s1 = (-s0-1) .>>. 1
+                                      in  T2 s1 (0x1000000 .>>. s1)
+
+                             -- install exponent bit
+                             p3 = if b0 /= 0
+                                    then p2 .|. (0x800000 .>>. s2)
+                                    else p2
+
+                             -- unrounded fraction
+                             p4 = (p3 .<<. s2) .|. (f .&. 0x7fffff)
+
+                             b1 = 0x400 .<<. s2 -- bit n+1
+                             p5 = if p4 .&. b1 /= 0 && (p4 .&. (b1-1) /= 0 || p4 .&. (b1 .<<. 1) /= 0)
+                                    then p4 + b1
+                                    else p4
+                           in
+                           p5 .>>. (s2 + 11)
+                in
+                testBit f 31 ? ( 0x10000 - p1, p1 )
+

--- a/src/POSIT.hs
+++ b/src/POSIT.hs
@@ -46,24 +46,24 @@ p16_to_f32 (P16_ p) = bitcast f
              -- decode |p|
              then
                let -- decode regime
-                   f0       = sign /= 0 ? ( 0x10000 - p, p )
-                   T2 f1 s1 =
-                     let u = f0 .&. 0x4000 /= 0
-                         v = u ? (complement f0, f0)
-                         w = countLeadingZeros (v .<<. 2)
-                         x = 0x1000000 * w
-                     in
-                     T2 (fromIntegral f0 .<<. w)  -- XXX: requires 32-bits
-                        (u ? ( 0x3f800000 + x     -- XXX: must be signed
-                             , 0x3e800000 - x))
+                   f0 = sign /= 0 ? ( 0x10000 - p, p )
+
+                   u  = f0 .&. 0x4000 /= 0
+                   v  = u ? (complement f0, f0)
+                   w  = countLeadingZeros (v .<<. 2)
+                   x  = 0x1000000 * w
+
+                   f1 = fromIntegral f0 .<<. w  -- XXX: requires 32-bits
+                   s1 = u ? ( 0x3f800000 + x    -- XXX: must be signed
+                            , 0x3e800000 - x)
 
                    -- decode exponent bit
-                   shift =
+                   s2 =
                      if f1 .&. 0x1000 /= 0
                        then s1 + 0x800000
                        else s1
                in
-               sign .|. fromIntegral shift .|. ((f1 .&. 0x0FFF) .<<. 11)
+               sign .|. fromIntegral s2 .|. ((f1 .&. 0x0FFF) .<<. 11)
 
              -- exception cases NaN and zero
              else

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,17 +11,17 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 extra-deps:
 - git:    https://github.com/tmcdonell/accelerate.git
-  commit: dbb21b8f42e2051faf648d0a8718f9bf801a82d8
+  commit: d948d737683bc2f340b56319a4412505274502fc
 
 - git:    https://github.com/tmcdonell/accelerate-llvm.git
-  commit: a8370e918182654d76225c5a805e891a9fd67d0c
+  commit: a7a5c89a35f766dd14f6f2a982ea165bed0fcac1
   subdirs:
     - accelerate-llvm
     - accelerate-llvm-native
     - accelerate-llvm-ptx
 
 - git:    https://github.com/tmcdonell/accelerate-fft.git
-  commit: a8da5921f425e07c8536f778a92267e145eab016
+  commit: 782a873c000a89fd521e1ce4107daaf14bdc819d
 
 - git:    https://github.com/tmcdonell/lens-accelerate.git
   commit: b74eb8098735b1ad6cff3c5655af03d3f29b9f8e

--- a/test/POSIT.hs
+++ b/test/POSIT.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE TypeApplications #-}
+
+import POSIT
+
+import Data.Array.Accelerate             as A
+import Data.Array.Accelerate.Debug       as A
+import Data.Array.Accelerate.Data.Bits   as A
+import Data.Array.Accelerate.Interpreter as I
+import Data.Array.Accelerate.LLVM.Native as CPU
+
+
+roundtrip :: Exp Word16 -> Exp Word16
+roundtrip p =
+  let f      = p16_to_f32 (P16_ p)
+      P16_ q = f32_to_p16 f
+  in
+  q
+
+exhaustive :: Acc (Vector (Word16, Word16), Scalar Int)
+exhaustive =
+  let ws  = enumFromN (index1 65536) 0
+      ws' = map roundtrip ws
+  in
+  filter (uncurry (/=)) (zip ws ws')
+


### PR DESCRIPTION
Conversions between 32-bit IEEE and 16-bit POSIT format; threaded and vectorised. I didn't include 64-bit IEEE, but it should be much the same with slightly different bit masks; the only thing to check would be to ensure the intermediate computations don't overflow (see `f32_to_p16`).